### PR TITLE
Remove static export configuration

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export',
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
## Summary
- remove the static `output: 'export'` setting so the Next.js runtime can execute API routes

## Testing
- npm run dev
- curl -i http://localhost:3000/api/chalets


------
https://chatgpt.com/codex/tasks/task_e_68dc14834f1c832e82383525af083ca0