### PR TITLE
Add authentication portal page and portfolio seed script

### DIFF
--- a/app/auth/page.js
+++ b/app/auth/page.js
@@ -1,0 +1,354 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import ClientIcon from '../../components/ClientIcon';
+
+const LOGIN_MODE = 'login';
+const REGISTER_MODE = 'register';
+
+const INITIAL_FORM = {
+  username: '',
+  email: '',
+  password: '',
+  confirmPassword: ''
+};
+
+export default function AuthPage() {
+  const [mode, setMode] = useState(LOGIN_MODE);
+  const [form, setForm] = useState(INITIAL_FORM);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    try {
+      const storedUser = typeof window !== 'undefined' ? localStorage.getItem('authUser') : null;
+      const storedToken = typeof window !== 'undefined' ? localStorage.getItem('authToken') : null;
+
+      if (storedUser && storedToken) {
+        const parsedUser = JSON.parse(storedUser);
+        if (parsedUser?.role === 'admin') {
+          router.replace('/admin/dashboard');
+        }
+      }
+    } catch (err) {
+      console.warn('Unable to restore auth session', err);
+    }
+  }, [router]);
+
+  const isLoginMode = useMemo(() => mode === LOGIN_MODE, [mode]);
+
+  const toggleMode = () => {
+    setMode((prev) => (prev === LOGIN_MODE ? REGISTER_MODE : LOGIN_MODE));
+    setForm(INITIAL_FORM);
+    setError('');
+    setSuccess('');
+  };
+
+  const handleChange = (event) => {
+    const { name, value } = event.target;
+    setForm((prev) => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setLoading(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      if (!isLoginMode && form.password !== form.confirmPassword) {
+        setError('Les mots de passe ne correspondent pas.');
+        return;
+      }
+
+      const payload = isLoginMode
+        ? { username: form.username.trim(), password: form.password }
+        : {
+            username: form.username.trim(),
+            email: form.email.trim(),
+            password: form.password
+          };
+
+      const endpoint = isLoginMode ? '/api/auth/login' : '/api/auth/register';
+
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+
+      const data = await response.json();
+
+      if (!data?.success) {
+        throw new Error(data?.message || "Une erreur est survenue lors de l'authentification.");
+      }
+
+      const targetUser = data.user ?? null;
+      const token = data.token ?? null;
+
+      if (token && typeof window !== 'undefined') {
+        localStorage.setItem('authToken', token);
+        localStorage.setItem('authUser', JSON.stringify(targetUser));
+
+        if (targetUser?.role === 'admin') {
+          localStorage.setItem('adminToken', token);
+          localStorage.setItem('adminUser', JSON.stringify(targetUser));
+        }
+      }
+
+      if (isLoginMode) {
+        setSuccess('Connexion réussie. Redirection en cours...');
+      } else {
+        setSuccess('Compte créé avec succès. Redirection en cours...');
+      }
+
+      setTimeout(() => {
+        if (targetUser?.role === 'admin') {
+          router.replace('/admin/dashboard');
+        } else {
+          router.replace('/');
+        }
+      }, 800);
+    } catch (err) {
+      setError(err.message || "Impossible d'effectuer la requête.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-neutral-50 flex flex-col lg:flex-row">
+      <div className="relative w-full lg:w-1/2 flex items-center justify-center px-6 py-16 overflow-hidden">
+        <div className="absolute inset-0">
+          <div className="absolute inset-0 bg-gradient-to-br from-primary-700 via-primary-600 to-primary-500 opacity-90" />
+          <div
+            className="absolute inset-0"
+            style={{
+              backgroundImage:
+                'url(https://images.pexels.com/photos/1129187/pexels-photo-1129187.jpeg)',
+              backgroundSize: 'cover',
+              backgroundPosition: 'center',
+              mixBlendMode: 'multiply'
+            }}
+          />
+        </div>
+
+        <div className="relative z-10 max-w-lg text-white space-y-8">
+          <div className="flex items-center gap-3">
+            <div className="w-12 h-12 rounded-full bg-white/10 flex items-center justify-center">
+              <ClientIcon name="ShieldCheck" className="w-6 h-6" />
+            </div>
+            <span className="uppercase tracking-[0.4em] text-sm font-semibold text-white/80">ESPACE MEMBRE</span>
+          </div>
+
+          <h1 className="text-4xl lg:text-5xl font-bold leading-tight">
+            Gérez vos chalets avec une plateforme sécurisée et intuitive.
+          </h1>
+
+          <p className="text-white/80 text-lg">
+            Accédez à vos outils de suivi, mettez à jour vos contenus et collaborez avec notre équipe dédiée depuis une seule interface.
+          </p>
+
+          <ul className="space-y-4">
+            {["Connexion sécurisée par jeton", 'Gestion du contenu portfolio', 'Support dédié 7j/7'].map((feature) => (
+              <li key={feature} className="flex items-start gap-3">
+                <div className="mt-1">
+                  <ClientIcon name="CheckCircle" className="w-5 h-5 text-emerald-300" />
+                </div>
+                <span className="text-white/85 text-sm leading-relaxed">{feature}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="w-full lg:w-1/2 flex items-center justify-center px-6 sm:px-10 py-16">
+        <div className="w-full max-w-md space-y-8">
+          <div>
+            <h2 className="text-3xl font-bold text-neutral-900 mb-2">
+              {isLoginMode ? 'Connexion à votre espace' : 'Créer un compte gestionnaire'}
+            </h2>
+            <p className="text-neutral-600 text-sm">
+              {isLoginMode
+                ? 'Entrez vos identifiants pour accéder à la plateforme de gestion.'
+                : 'Renseignez vos informations pour activer votre accès sécurisé.'}
+            </p>
+          </div>
+
+          <div className="bg-white rounded-2xl shadow-lg p-8 space-y-6">
+            <div className="flex items-center justify-between bg-neutral-100 rounded-xl p-1">
+              <button
+                type="button"
+                onClick={() => setMode(LOGIN_MODE)}
+                className={`flex-1 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                  isLoginMode ? 'bg-white shadow text-neutral-900' : 'text-neutral-500'
+                }`}
+              >
+                Connexion
+              </button>
+              <button
+                type="button"
+                onClick={() => setMode(REGISTER_MODE)}
+                className={`flex-1 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                  !isLoginMode ? 'bg-white shadow text-neutral-900' : 'text-neutral-500'
+                }`}
+              >
+                Inscription
+              </button>
+            </div>
+
+            {error ? (
+              <div className="p-4 border border-red-200 bg-red-50 rounded-xl flex items-start gap-3">
+                <ClientIcon name="AlertCircle" className="w-5 h-5 text-red-500" />
+                <p className="text-sm text-red-700">{error}</p>
+              </div>
+            ) : null}
+
+            {success ? (
+              <div className="p-4 border border-emerald-200 bg-emerald-50 rounded-xl flex items-start gap-3">
+                <ClientIcon name="CircleCheck" className="w-5 h-5 text-emerald-600" />
+                <p className="text-sm text-emerald-700">{success}</p>
+              </div>
+            ) : null}
+
+            <form onSubmit={handleSubmit} className="space-y-5">
+              <div className="space-y-2">
+                <label htmlFor="username" className="text-sm font-medium text-neutral-700">
+                  Nom d'utilisateur
+                </label>
+                <div className="relative">
+                  <ClientIcon name="User" className="w-4 h-4 text-neutral-400 absolute left-3 top-1/2 -translate-y-1/2" />
+                  <input
+                    id="username"
+                    name="username"
+                    required
+                    value={form.username}
+                    onChange={handleChange}
+                    placeholder="ex: gestionnaire-alpes"
+                    className="w-full pl-10 pr-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  />
+                </div>
+              </div>
+
+              {!isLoginMode ? (
+                <div className="space-y-2">
+                  <label htmlFor="email" className="text-sm font-medium text-neutral-700">
+                    Adresse e-mail
+                  </label>
+                  <div className="relative">
+                    <ClientIcon name="Mail" className="w-4 h-4 text-neutral-400 absolute left-3 top-1/2 -translate-y-1/2" />
+                    <input
+                      id="email"
+                      name="email"
+                      type="email"
+                      required
+                      value={form.email}
+                      onChange={handleChange}
+                      placeholder="vous@exemple.com"
+                      className="w-full pl-10 pr-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              <div className="space-y-2">
+                <label htmlFor="password" className="text-sm font-medium text-neutral-700">
+                  Mot de passe
+                </label>
+                <div className="relative">
+                  <ClientIcon name="Lock" className="w-4 h-4 text-neutral-400 absolute left-3 top-1/2 -translate-y-1/2" />
+                  <input
+                    id="password"
+                    name="password"
+                    type="password"
+                    required
+                    value={form.password}
+                    onChange={handleChange}
+                    placeholder="********"
+                    className="w-full pl-10 pr-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  />
+                </div>
+              </div>
+
+              {!isLoginMode ? (
+                <div className="space-y-2">
+                  <label htmlFor="confirmPassword" className="text-sm font-medium text-neutral-700">
+                    Confirmation du mot de passe
+                  </label>
+                  <div className="relative">
+                    <ClientIcon name="Shield" className="w-4 h-4 text-neutral-400 absolute left-3 top-1/2 -translate-y-1/2" />
+                    <input
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type="password"
+                      required
+                      value={form.confirmPassword}
+                      onChange={handleChange}
+                      placeholder="********"
+                      className="w-full pl-10 pr-4 py-3 border border-neutral-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                    />
+                  </div>
+                </div>
+              ) : null}
+
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-primary-700 text-white rounded-lg font-semibold hover:bg-primary-800 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              >
+                {loading ? (
+                  <>
+                    <span className="h-4 w-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                    Traitement...
+                  </>
+                ) : (
+                  <>
+                    <ClientIcon name={isLoginMode ? 'LogIn' : 'UserPlus'} className="w-5 h-5" />
+                    {isLoginMode ? 'Se connecter' : "Créer mon compte"}
+                  </>
+                )}
+              </button>
+            </form>
+
+            {isLoginMode ? (
+              <div className="text-right">
+                <Link href="/contact" className="text-sm text-primary-700 hover:text-primary-800 font-medium">
+                  Besoin d'aide ? Contactez-nous
+                </Link>
+              </div>
+            ) : null}
+          </div>
+
+          <p className="text-xs text-neutral-500 text-center">
+            En vous connectant, vous acceptez nos conditions générales d'utilisation et notre politique de confidentialité.
+          </p>
+
+          <p className="text-sm text-neutral-600 text-center">
+            {isLoginMode ? (
+              <>
+                Pas encore de compte ?{' '}
+                <button type="button" onClick={toggleMode} className="text-primary-700 font-semibold hover:text-primary-800">
+                  Créer un accès
+                </button>
+              </>
+            ) : (
+              <>
+                Vous avez déjà un accès ?{' '}
+                <button type="button" onClick={toggleMode} className="text-primary-700 font-semibold hover:text-primary-800">
+                  Se connecter
+                </button>
+              </>
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev -H 0.0.0.0 -p 3000",
     "build": "next build",
     "start": "next start -H 0.0.0.0 -p 3000",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed": "node seed.js"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.0",

--- a/seed.js
+++ b/seed.js
@@ -1,0 +1,426 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+
+function loadEnv() {
+  const envFiles = ['.env.local', '.env'];
+
+  for (const fileName of envFiles) {
+    const fullPath = path.join(process.cwd(), fileName);
+    if (!fs.existsSync(fullPath)) {
+      continue;
+    }
+
+    const raw = fs.readFileSync(fullPath, 'utf8');
+    const lines = raw.split(/\r?\n/);
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue;
+      }
+
+      const delimiterIndex = trimmed.indexOf('=');
+      if (delimiterIndex === -1) {
+        continue;
+      }
+
+      const key = trimmed.slice(0, delimiterIndex).trim();
+      let value = trimmed.slice(delimiterIndex + 1).trim();
+
+      if (!key || Object.prototype.hasOwnProperty.call(process.env, key)) {
+        continue;
+      }
+
+      if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'"))
+      ) {
+        value = value.slice(1, -1);
+      }
+
+      process.env[key] = value;
+    }
+  }
+}
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^\w ]+/g, '')
+    .replace(/ +/g, '-')
+    .trim();
+}
+
+async function ensureAdminUser(UserModel) {
+  const username = (process.env.SEED_ADMIN_USERNAME || 'gestionnaire-alpes').toLowerCase();
+  const email = (process.env.SEED_ADMIN_EMAIL || 'gestionnaire@portage.local').toLowerCase();
+  const password = process.env.SEED_ADMIN_PASSWORD || 'GestionPortage123!';
+
+  let user = await UserModel.findOne({ email });
+
+  if (!user) {
+    user = await UserModel.create({
+      username,
+      email,
+      password,
+      role: 'admin'
+    });
+    console.log(`✔️  Utilisateur administrateur créé : ${email}`);
+  } else {
+    console.log(`ℹ️  Utilisateur administrateur déjà présent : ${email}`);
+  }
+
+  return user;
+}
+
+function buildChaletSeeds() {
+  return [
+    {
+      title: 'Chalet Aster des Cimes',
+      description:
+        "Situé au cœur de Chamonix, le Chalet Aster des Cimes offre une vue panoramique sur le Mont-Blanc. Ses espaces de vie lumineux et son spa nordique en extérieur en font un lieu idéal pour les séjours en famille ou entre amis. Chaque détail a été conçu pour offrir un confort absolu, des matériaux nobles aux équipements haut de gamme.",
+      shortDescription:
+        'Un chalet lumineux à Chamonix avec spa nordique extérieur et cinq suites.',
+      images: [
+        {
+          url: 'https://images.pexels.com/photos/1127119/pexels-photo-1127119.jpeg',
+          alt: 'Façade enneigée du Chalet Aster des Cimes',
+          caption: 'Une architecture alpine contemporaine',
+          isHero: true
+        },
+        {
+          url: 'https://images.pexels.com/photos/259588/pexels-photo-259588.jpeg',
+          alt: 'Salon du Chalet Aster des Cimes',
+          caption: 'Salon cathédrale avec cheminée centrale'
+        },
+        {
+          url: 'https://images.pexels.com/photos/276724/pexels-photo-276724.jpeg',
+          alt: 'Spa nordique du Chalet Aster des Cimes',
+          caption: 'Spa nordique chauffé face aux montagnes'
+        }
+      ],
+      amenities: [
+        { name: 'Spa nordique', icon: 'Spa', description: 'Bain norvégien extérieur chauffé toute l’année.' },
+        { name: 'Cheminée centrale', icon: 'Fireplace', description: 'Cheminée double face pour des soirées conviviales.' },
+        { name: 'Salle de cinéma', icon: 'Clapperboard', description: 'Espace multimédia avec système Dolby Atmos.' },
+        { name: 'Ski room chauffé', icon: 'Snowflake', description: 'Rangements dédiés avec chauffe-chaussures.' }
+      ],
+      specifications: {
+        bedrooms: 5,
+        bathrooms: 5,
+        maxGuests: 12,
+        area: 320,
+        floors: 3
+      },
+      location: {
+        address: '89 Route des Pèlerins',
+        city: 'Chamonix',
+        country: 'France',
+        postalCode: '74400',
+        coordinates: {
+          latitude: 45.923697,
+          longitude: 6.869433
+        }
+      },
+      pricing: {
+        basePrice: 780,
+        currency: 'EUR',
+        cleaningFee: 120,
+        securityDeposit: 1500,
+        taxRate: 10
+      },
+      availability: {
+        isActive: true,
+        minimumStay: 3,
+        maximumStay: 21,
+        checkInTime: '16:00',
+        checkOutTime: '10:00',
+        blockedDates: []
+      },
+      contact: {
+        phone: '+33 4 50 53 00 00',
+        email: 'aster@portage-salarial.fr',
+        website: 'https://www.portage-salarial.fr/chalets/aster-des-cimes'
+      },
+      seo: {
+        metaTitle: 'Chalet Aster des Cimes - Chamonix',
+        metaDescription: 'Chalet d’exception à Chamonix avec spa nordique, salle de cinéma et vue Mont-Blanc.'
+      },
+      featured: true
+    },
+    {
+      title: 'Chalet Lueur des Alpes',
+      description:
+        "Perché sur les hauteurs de Megève, le Chalet Lueur des Alpes propose une atmosphère chaleureuse mêlant tradition et modernité. Sa terrasse panoramique et sa piscine intérieure à débordement invitent à la détente après une journée sur les pistes.",
+      shortDescription: 'Prestige à Megève avec piscine intérieure et service de conciergerie 24/7.',
+      images: [
+        {
+          url: 'https://images.pexels.com/photos/280229/pexels-photo-280229.jpeg',
+          alt: 'Vue extérieure du Chalet Lueur des Alpes',
+          caption: 'Architecture traditionnelle et bardage bois',
+          isHero: true
+        },
+        {
+          url: 'https://images.pexels.com/photos/276551/pexels-photo-276551.jpeg',
+          alt: 'Piscine intérieure du Chalet Lueur des Alpes',
+          caption: 'Piscine intérieure à débordement avec vue'
+        },
+        {
+          url: 'https://images.pexels.com/photos/259962/pexels-photo-259962.jpeg',
+          alt: 'Suite parentale du Chalet Lueur des Alpes',
+          caption: 'Suite parentale avec dressing et salle de bain marbre'
+        }
+      ],
+      amenities: [
+        { name: 'Piscine intérieure', icon: 'Waves', description: 'Piscine chauffée avec nage à contre-courant.' },
+        { name: 'Conciergerie 24/7', icon: 'Headset', description: 'Service personnalisé pour chaque séjour.' },
+        { name: 'Salle de sport', icon: 'Dumbbell', description: 'Espace fitness équipé Technogym.' },
+        { name: 'Héliport privé', icon: 'Helicopter', description: 'Plateforme privée pour transferts rapides.' }
+      ],
+      specifications: {
+        bedrooms: 6,
+        bathrooms: 6,
+        maxGuests: 14,
+        area: 410,
+        floors: 4
+      },
+      location: {
+        address: '210 Chemin des Bois',
+        city: 'Megève',
+        country: 'France',
+        postalCode: '74120',
+        coordinates: {
+          latitude: 45.8575,
+          longitude: 6.6136
+        }
+      },
+      pricing: {
+        basePrice: 980,
+        currency: 'EUR',
+        cleaningFee: 150,
+        securityDeposit: 2500,
+        taxRate: 12
+      },
+      availability: {
+        isActive: true,
+        minimumStay: 4,
+        maximumStay: 28,
+        checkInTime: '15:00',
+        checkOutTime: '11:00',
+        blockedDates: []
+      },
+      contact: {
+        phone: '+33 4 50 93 01 01',
+        email: 'lueur@portage-salarial.fr',
+        website: 'https://www.portage-salarial.fr/chalets/lueur-des-alpes'
+      },
+      seo: {
+        metaTitle: 'Chalet Lueur des Alpes - Megève',
+        metaDescription: 'Chalet de prestige à Megève avec piscine intérieure, héliport privé et conciergerie.'
+      },
+      featured: false
+    },
+    {
+      title: 'Chalet Horizon Belle Plagne',
+      description:
+        "Dominant la vallée de la Tarentaise, le Chalet Horizon Belle Plagne combine un design contemporain et l’authenticité savoyarde. Sa grande pièce de vie avec baies vitrées ouvre sur un panorama exceptionnel et une terrasse chauffée.",
+      shortDescription: 'Belle Plagne panoramique avec terrasse chauffée et espace bien-être.',
+      images: [
+        {
+          url: 'https://images.pexels.com/photos/210415/pexels-photo-210415.jpeg',
+          alt: 'Terrasse panoramique du Chalet Horizon',
+          caption: 'Terrasse chauffée avec vue sur la Tarentaise',
+          isHero: true
+        },
+        {
+          url: 'https://images.pexels.com/photos/276583/pexels-photo-276583.jpeg',
+          alt: 'Cuisine moderne du Chalet Horizon',
+          caption: 'Cuisine ouverte équipée Gaggenau'
+        },
+        {
+          url: 'https://images.pexels.com/photos/259803/pexels-photo-259803.jpeg',
+          alt: 'Chambre du Chalet Horizon Belle Plagne',
+          caption: 'Chambres avec balcon et vue montagne'
+        }
+      ],
+      amenities: [
+        { name: 'Sauna et hammam', icon: 'HotTub', description: 'Espace bien-être complet.' },
+        { name: 'Terrasse chauffée', icon: 'Sun', description: 'Terrasse avec braseros et salons extérieurs.' },
+        { name: 'Garage 4 véhicules', icon: 'Car', description: 'Garage couvert avec borne de recharge.' }
+      ],
+      specifications: {
+        bedrooms: 4,
+        bathrooms: 4,
+        maxGuests: 10,
+        area: 260,
+        floors: 3
+      },
+      location: {
+        address: '52 Route de Belle Plagne',
+        city: 'La Plagne',
+        country: 'France',
+        postalCode: '73210',
+        coordinates: {
+          latitude: 45.5102,
+          longitude: 6.6778
+        }
+      },
+      pricing: {
+        basePrice: 640,
+        currency: 'EUR',
+        cleaningFee: 110,
+        securityDeposit: 1800,
+        taxRate: 10
+      },
+      availability: {
+        isActive: true,
+        minimumStay: 3,
+        maximumStay: 14,
+        checkInTime: '17:00',
+        checkOutTime: '10:00',
+        blockedDates: []
+      },
+      contact: {
+        phone: '+33 4 79 09 77 77',
+        email: 'horizon@portage-salarial.fr',
+        website: 'https://www.portage-salarial.fr/chalets/horizon-belle-plagne'
+      },
+      seo: {
+        metaTitle: 'Chalet Horizon Belle Plagne',
+        metaDescription: 'Chalet contemporain à Belle Plagne avec terrasse chauffée et espace bien-être.'
+      },
+      featured: false
+    }
+  ];
+}
+
+function buildPortfolioDescription(chalet) {
+  return `Situé à ${chalet.location.city}, ${chalet.title} dispose de ${chalet.specifications.bedrooms} chambres et peut accueillir jusqu'à ${chalet.specifications.maxGuests} personnes. Ses équipements premium tels que ${chalet.amenities.slice(0, 2).map((a) => a.name).join(' et ')} en font un refuge idéal pour des séjours d'exception.`;
+}
+
+function buildCustomImages(chalet) {
+  return (chalet.images || []).slice(0, 2).map((image, index) => ({
+    url: image.url,
+    alt: `${chalet.title} - ${index === 0 ? 'Vue extérieure' : 'Intérieur'}`,
+    caption: image.caption || `${chalet.title} - ${index === 0 ? 'Vue panoramique' : 'Espace de vie'}`,
+    isHero: index === 0
+  }));
+}
+
+async function seedPortfolio({ ChaletModel, PortfolioItemModel }) {
+  const seeds = buildChaletSeeds();
+  const results = [];
+
+  for (const [index, seed] of seeds.entries()) {
+    const expectedSlug = slugify(seed.title);
+    let chalet = await ChaletModel.findOne({ slug: expectedSlug });
+
+    if (!chalet) {
+      chalet = await ChaletModel.create(seed);
+      console.log(`✔️  Chalet créé : ${seed.title}`);
+    } else {
+      chalet.set(seed);
+      await chalet.save();
+      console.log(`ℹ️  Chalet mis à jour : ${seed.title}`);
+    }
+
+    let portfolio = await PortfolioItemModel.findOne({ chalet: chalet._id });
+
+    const description = buildPortfolioDescription(chalet);
+    const customImages = buildCustomImages(chalet);
+
+    if (!portfolio) {
+      portfolio = await PortfolioItemModel.create({
+        chalet: chalet._id,
+        featured: index === 0,
+        displayOrder: index + 1,
+        customDescription: description,
+        customImages,
+        externalBookingUrl: `${chalet.contact.website}#reservation`,
+        showOnPortfolio: true,
+        seoTitle: `${chalet.title} - Chalet de prestige`,
+        seoDescription: description.slice(0, 155),
+        tags: [chalet.location.city, 'montagne', 'luxe']
+      });
+      console.log(`✔️  Élément de portfolio créé pour ${chalet.title}`);
+    } else {
+      portfolio.set({
+        featured: index === 0,
+        displayOrder: index + 1,
+        customDescription: description,
+        customImages,
+        externalBookingUrl: `${chalet.contact.website}#reservation`,
+        showOnPortfolio: true,
+        seoTitle: `${chalet.title} - Chalet de prestige`,
+        seoDescription: description.slice(0, 155)
+      });
+      const tags = new Set([...(portfolio.tags || []), chalet.location.city, 'montagne', 'luxe']);
+      portfolio.tags = Array.from(tags);
+      await portfolio.save();
+      console.log(`ℹ️  Élément de portfolio mis à jour pour ${chalet.title}`);
+    }
+
+    results.push({ chalet, portfolio });
+  }
+
+  return results;
+}
+
+async function createPortfolioContent(createFakeContentFn) {
+  const created = await createFakeContentFn({ page: 'portfolio', count: 3 });
+  console.log(`✔️  Contenus éditoriaux générés pour la page portfolio (${created.length} entrées).`);
+  return created;
+}
+
+async function main() {
+  loadEnv();
+
+  if (!process.env.MONGODB_URI) {
+    throw new Error('La variable d\'environnement MONGODB_URI est requise pour exécuter le script de seed.');
+  }
+
+  const mongoose = (await import('mongoose')).default;
+  const { default: dbConnect } = await import('./lib/mongodb.js');
+  const { createFakeContent } = await import('./lib/seed/fakeContent.js');
+  const { default: User } = await import('./models/User.js');
+  const { default: Chalet } = await import('./models/Chalet.js');
+  const { default: PortfolioItem } = await import('./models/PortfolioItem.js');
+
+  await dbConnect();
+
+  const admin = await ensureAdminUser(User);
+  const seededPortfolio = await seedPortfolio({ ChaletModel: Chalet, PortfolioItemModel: PortfolioItem });
+  const contentEntries = await createPortfolioContent(createFakeContent);
+
+  console.log('\nRésumé du seed :');
+  console.table([
+    {
+      type: 'Utilisateur',
+      details: admin.email,
+      action: 'assuré'
+    },
+    ...seededPortfolio.map(({ chalet }) => ({
+      type: 'Chalet',
+      details: chalet.title,
+      action: 'synchronisé'
+    })),
+    ...contentEntries.map((entry) => ({
+      type: 'Contenu',
+      details: `${entry.page} / ${entry.section}`,
+      action: 'créé'
+    }))
+  ]);
+
+  await mongoose.connection.close();
+}
+
+main()
+  .then(() => {
+    console.log('\n✅  Script de seed terminé avec succès.');
+    process.exit(0);
+  })
+  .catch((error) => {
+    console.error('\n❌  Le script de seed a échoué :', error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- add a dedicated `/auth` page with login/registration flows and onboarding UI
- introduce a comprehensive `seed.js` script that creates demo chalets, portfolio entries, and editorial content while ensuring an admin account exists
- expose an `npm run seed` command for running the new seed script

## Testing
- npm run lint *(fails: existing lint configuration flags numerous pre-existing violations)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3301ad3c832eb201ca39e91c1aea