### PR TITLE
Convert Next.js config to ES module export

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,4 +6,4 @@ const nextConfig = {
   images: { unoptimized: true },
 };
 
-module.exports = nextConfig;
+export default nextConfig;


### PR DESCRIPTION
## Summary
- switch `next.config.js` to use an ES module export to match the package module type

## Testing
- npm run dev *(fails: `next` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dce9dd8ee0832eba6cc51e695fe19b