### PR TITLE
Convert postcss config to ESM

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,8 @@
-module.exports = {
+const config = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
 };
+
+export default config;


### PR DESCRIPTION
## Summary
- refactor the PostCSS configuration to use an ES module default export for compatibility with Next.js

## Testing
- `npm run dev` *(fails: next not found because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dceb8717c8832ea292cb0398d0ff85