### PR TITLE
feat: persist signup data with accordion flow

### DIFF
--- a/app/api/signup/route.js
+++ b/app/api/signup/route.js
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '../../../lib/mongodb';
+import SignupApplication from '../../../models/SignupApplication';
+
+const isNonEmptyString = (value) => typeof value === 'string' && value.trim().length > 0;
+
+const validateOwnerPayload = (data) => {
+  if (!data) return 'Les informations du propriétaire sont manquantes.';
+
+  if (!isNonEmptyString(data.title) || !isNonEmptyString(data.shortDescription) || !isNonEmptyString(data.longDescription)) {
+    return 'Veuillez renseigner les informations principales du chalet.';
+  }
+
+  const propertyAddress = data.propertyAddress || {};
+  if (
+    !isNonEmptyString(propertyAddress.streetNumber) ||
+    !isNonEmptyString(propertyAddress.streetName) ||
+    !isNonEmptyString(propertyAddress.city) ||
+    !isNonEmptyString(propertyAddress.country)
+  ) {
+    return "Veuillez compléter l'adresse du chalet.";
+  }
+
+  const owner = data.owner || {};
+  if (!isNonEmptyString(owner.firstName) || !isNonEmptyString(owner.lastName) || !isNonEmptyString(owner.email) || !isNonEmptyString(owner.birthDate)) {
+    return 'Veuillez compléter les informations personnelles du propriétaire.';
+  }
+
+  const mainAddress = data.mainAddress || {};
+  if (
+    !isNonEmptyString(mainAddress.streetNumber) ||
+    !isNonEmptyString(mainAddress.streetName) ||
+    !isNonEmptyString(mainAddress.city) ||
+    !isNonEmptyString(mainAddress.country)
+  ) {
+    return "Veuillez compléter l'adresse principale du propriétaire.";
+  }
+
+  return null;
+};
+
+const validateSeekerPayload = (data) => {
+  if (!data) return 'Les informations du locataire sont manquantes.';
+
+  if (!isNonEmptyString(data.firstName) || !isNonEmptyString(data.lastName) || !isNonEmptyString(data.email)) {
+    return 'Veuillez renseigner vos informations de contact.';
+  }
+
+  if (!isNonEmptyString(data.preferredRegion)) {
+    return 'Veuillez préciser la destination recherchée.';
+  }
+
+  return null;
+};
+
+export async function POST(request) {
+  try {
+    const { type, data } = await request.json();
+
+    if (!['owner', 'seeker'].includes(type)) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: "Le type de candidature est invalide."
+        },
+        { status: 400 }
+      );
+    }
+
+    const validationError = type === 'owner' ? validateOwnerPayload(data) : validateSeekerPayload(data);
+    if (validationError) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: validationError
+        },
+        { status: 400 }
+      );
+    }
+
+    await dbConnect();
+
+    const application = await SignupApplication.create({
+      type,
+      ownerData: type === 'owner' ? data : undefined,
+      seekerData: type === 'seeker' ? data : undefined
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: 'Candidature enregistrée avec succès.',
+      applicationId: application._id
+    });
+  } catch (error) {
+    console.error('Signup API error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: "Une erreur interne est survenue. Veuillez réessayer plus tard."
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/models/SignupApplication.js
+++ b/models/SignupApplication.js
@@ -1,0 +1,106 @@
+import mongoose from 'mongoose';
+
+const FileMetadataSchema = new mongoose.Schema(
+  {
+    name: { type: String, default: '' },
+    size: { type: Number, default: 0 },
+    type: { type: String, default: '' },
+    lastModified: { type: Number, default: null }
+  },
+  { _id: false }
+);
+
+const AddressSchema = new mongoose.Schema(
+  {
+    streetNumber: { type: String, default: '' },
+    streetName: { type: String, default: '' },
+    line2: { type: String, default: '' },
+    city: { type: String, default: '' },
+    postalCode: { type: String, default: '' },
+    country: { type: String, default: '' }
+  },
+  { _id: false }
+);
+
+const RoomSchema = new mongoose.Schema(
+  {
+    name: { type: String, default: '' },
+    description: { type: String, default: '' },
+    photos: { type: [FileMetadataSchema], default: [] }
+  },
+  { _id: false }
+);
+
+const OwnerDetailsSchema = new mongoose.Schema(
+  {
+    firstName: { type: String, default: '' },
+    lastName: { type: String, default: '' },
+    birthDate: { type: String, default: '' },
+    email: { type: String, default: '' },
+    phone: { type: String, default: '' }
+  },
+  { _id: false }
+);
+
+const OwnerApplicationSchema = new mongoose.Schema(
+  {
+    title: { type: String, default: '' },
+    slug: { type: String, default: '' },
+    shortDescription: { type: String, default: '' },
+    longDescription: { type: String, default: '' },
+    heroPhoto: { type: [FileMetadataSchema], default: [] },
+    gallery: { type: [FileMetadataSchema], default: [] },
+    rooms: { type: [RoomSchema], default: [] },
+    propertyAddress: { type: AddressSchema, default: () => ({}) },
+    mainAddress: { type: AddressSchema, default: () => ({}) },
+    owner: { type: OwnerDetailsSchema, default: () => ({}) },
+    identityDocument: { type: [FileMetadataSchema], default: [] },
+    ownershipProof: { type: [FileMetadataSchema], default: [] }
+  },
+  { _id: false }
+);
+
+const SeekerApplicationSchema = new mongoose.Schema(
+  {
+    firstName: { type: String, default: '' },
+    lastName: { type: String, default: '' },
+    email: { type: String, default: '' },
+    phone: { type: String, default: '' },
+    preferredRegion: { type: String, default: '' },
+    desiredDates: { type: String, default: '' },
+    guests: { type: String, default: '' },
+    budget: { type: String, default: '' },
+    requirements: { type: String, default: '' }
+  },
+  { _id: false }
+);
+
+const SignupApplicationSchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      enum: ['owner', 'seeker'],
+      required: true
+    },
+    status: {
+      type: String,
+      enum: ['pending', 'reviewed'],
+      default: 'pending'
+    },
+    ownerData: {
+      type: OwnerApplicationSchema,
+      required: function () {
+        return this.type === 'owner';
+      }
+    },
+    seekerData: {
+      type: SeekerApplicationSchema,
+      required: function () {
+        return this.type === 'seeker';
+      }
+    }
+  },
+  { timestamps: true }
+);
+
+export default mongoose.models.SignupApplication || mongoose.model('SignupApplication', SignupApplicationSchema);


### PR DESCRIPTION
## Summary
- add a MongoDB signup application model and API endpoint to persist owner and seeker submissions
- refactor the signup page into accordion-based modules with completion indicators and split street number inputs
- wire the forms to the new API with loading states, validation feedback, and reset behaviour

## Testing
- npm run lint *(fails: next not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd0ca02d70832e87f864b1f31ad84d