### PR TITLE
Add tenant signup type and collapsible room sections

### DIFF
--- a/models/SignupApplication.js
+++ b/models/SignupApplication.js
@@ -60,7 +60,7 @@ const OwnerApplicationSchema = new mongoose.Schema(
   { _id: false }
 );
 
-const SeekerApplicationSchema = new mongoose.Schema(
+const TenantApplicationSchema = new mongoose.Schema(
   {
     firstName: { type: String, default: '' },
     lastName: { type: String, default: '' },
@@ -79,7 +79,7 @@ const SignupApplicationSchema = new mongoose.Schema(
   {
     type: {
       type: String,
-      enum: ['owner', 'seeker'],
+      enum: ['owner', 'tenant'],
       required: true
     },
     status: {
@@ -93,10 +93,10 @@ const SignupApplicationSchema = new mongoose.Schema(
         return this.type === 'owner';
       }
     },
-    seekerData: {
-      type: SeekerApplicationSchema,
+    tenantData: {
+      type: TenantApplicationSchema,
       required: function () {
-        return this.type === 'seeker';
+        return this.type === 'tenant';
       }
     }
   },


### PR DESCRIPTION
## Summary
- allow each owner room card to be collapsed or expanded with an accordion-style toggle and add an explicit close control for form sections
- rename the seeker journey to tenant throughout the signup experience and reset room visibility alongside owner form state
- normalize signup API persistence to store `owner` or `tenant` applications and update the schema accordingly

## Testing
- npm run lint *(fails: next command unavailable in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd10960a74832eac08dc6e048853d5