### PR TITLE
Show submission actions only when signup forms are complete

### DIFF
--- a/app/signup/page.js
+++ b/app/signup/page.js
@@ -1159,7 +1159,7 @@ export default function SignUpPage() {
       {renderAccordion(ownerModules, ownerActiveModule, setOwnerActiveModule)}
 
       <div className="flex flex-col items-start justify-between gap-4 rounded-3xl border border-primary-200 bg-primary-50/70 px-6 py-6 md:flex-row md:items-center">
-        <div>
+        <div className="space-y-2">
           <h3 className="text-lg font-semibold text-primary-700">
             Validation de votre candidature
           </h3>
@@ -1167,20 +1167,28 @@ export default function SignUpPage() {
             Notre équipe analysera les informations fournies et vous
             recontactera rapidement pour finaliser l'onboarding de votre chalet.
           </p>
+          {isOwnerFormValid && (
+            <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-600">
+              <ClientIcon name="CheckCircle2" className="h-4 w-4" />
+              Complété
+            </span>
+          )}
         </div>
 
-        <button
-          type="submit"
-          disabled={ownerSubmitting}
-          className={`inline-flex items-center gap-2 rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg transition ${
-            ownerSubmitting
-              ? "bg-primary-400 cursor-not-allowed"
-              : "bg-primary-600 hover:bg-primary-700"
-          }`}
-        >
-          <ClientIcon name="Send" className="h-4 w-4" />
-          {ownerSubmitting ? "Envoi en cours..." : "Envoyer ma candidature"}
-        </button>
+        {isOwnerFormValid && (
+          <button
+            type="submit"
+            disabled={ownerSubmitting}
+            className={`inline-flex items-center gap-2 rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg transition ${
+              ownerSubmitting
+                ? "bg-primary-400 cursor-not-allowed"
+                : "bg-primary-600 hover:bg-primary-700"
+            }`}
+          >
+            <ClientIcon name="Send" className="h-4 w-4" />
+            {ownerSubmitting ? "Envoi en cours..." : "Envoyer ma candidature"}
+          </button>
+        )}
       </div>
     </form>
   );
@@ -1194,7 +1202,7 @@ export default function SignUpPage() {
       )}
 
       <div className="flex flex-col items-start justify-between gap-4 rounded-3xl border border-primary-200 bg-primary-50/70 px-6 py-6 md:flex-row md:items-center">
-        <div>
+        <div className="space-y-2">
           <h3 className="text-lg font-semibold text-primary-700">
             Recevoir ma sélection personnalisée
           </h3>
@@ -1202,20 +1210,28 @@ export default function SignUpPage() {
             Nous vous enverrons une première sélection de chalets correspondant
             à vos critères dans les plus brefs délais.
           </p>
+          {isTenantFormValid && (
+            <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-600">
+              <ClientIcon name="CheckCircle2" className="h-4 w-4" />
+              Complété
+            </span>
+          )}
         </div>
 
-        <button
-          type="submit"
-          disabled={tenantSubmitting}
-          className={`inline-flex items-center gap-2 rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg transition ${
-            tenantSubmitting
-              ? "bg-primary-400 cursor-not-allowed"
-              : "bg-primary-600 hover:bg-primary-700"
-          }`}
-        >
-          <ClientIcon name="Send" className="h-4 w-4" />
-          {tenantSubmitting ? "Envoi en cours..." : "Envoyer ma demande"}
-        </button>
+        {isTenantFormValid && (
+          <button
+            type="submit"
+            disabled={tenantSubmitting}
+            className={`inline-flex items-center gap-2 rounded-full px-6 py-3 text-sm font-semibold text-white shadow-lg transition ${
+              tenantSubmitting
+                ? "bg-primary-400 cursor-not-allowed"
+                : "bg-primary-600 hover:bg-primary-700"
+            }`}
+          >
+            <ClientIcon name="Send" className="h-4 w-4" />
+            {tenantSubmitting ? "Envoi en cours..." : "Envoyer ma demande"}
+          </button>
+        )}
       </div>
     </form>
   );


### PR DESCRIPTION
## Summary
- only display owner and tenant submission buttons once every required field is filled in
- surface a green completion badge in the confirmation panels when the corresponding form is complete

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd564d1b60832ebce10bd66b6f844f