### PR TITLE
Integrate Cloudinary-based media uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ A comprehensive multi-site web application for chalet management business, featu
    
    # Site Configuration
    NEXT_PUBLIC_SITE_URL=http://localhost:3000
+
+   # Cloudinary
+   CLOUDINARY_CLOUD_NAME=your-cloud-name
+   CLOUDINARY_API_KEY=your-api-key
+   CLOUDINARY_API_SECRET=your-api-secret
+   # Optional: customize the base folder that will contain all uploads
+   CLOUDINARY_BASE_FOLDER=portage-salarial
    ```
 
 4. **Database Setup**

--- a/app/api/uploads/route.js
+++ b/app/api/uploads/route.js
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import { createSignature, getCloudinaryConfig } from '../../../lib/cloudinary';
+
+export const runtime = 'nodejs';
+
+const sanitizeFolder = (folder) => {
+  if (typeof folder !== 'string') {
+    return '';
+  }
+
+  return folder
+    .split('/')
+    .map((segment) => segment.trim().replace(/[^a-zA-Z0-9-_]/g, ''))
+    .filter(Boolean)
+    .join('/');
+};
+
+const bufferFromFile = async (file) => {
+  if (!file || typeof file.arrayBuffer !== 'function') {
+    throw new Error('Invalid file received.');
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  return Buffer.from(arrayBuffer);
+};
+
+const uploadToCloudinary = async (file, { folder }) => {
+  const config = getCloudinaryConfig();
+
+  if (!config.isConfigured) {
+    throw new Error('Cloudinary n\'est pas configuré.');
+  }
+
+  const timestamp = Math.floor(Date.now() / 1000);
+  const normalizedFolder = sanitizeFolder(folder);
+  const targetFolder = [config.baseFolder, normalizedFolder].filter(Boolean).join('/');
+
+  const signature = createSignature({
+    folder: targetFolder,
+    timestamp
+  });
+
+  const body = new FormData();
+  const fileBuffer = await bufferFromFile(file);
+
+  body.append('file', new Blob([fileBuffer]), file.name || 'upload');
+  body.append('api_key', config.apiKey);
+  body.append('timestamp', String(timestamp));
+  body.append('signature', signature);
+  body.append('folder', targetFolder);
+
+  const response = await fetch(`https://api.cloudinary.com/v1_1/${config.cloudName}/auto/upload`, {
+    method: 'POST',
+    body
+  });
+
+  const payload = await response.json();
+
+  if (!response.ok || payload.error) {
+    throw new Error(payload?.error?.message || 'Échec du téléversement sur Cloudinary.');
+  }
+
+  return {
+    assetId: payload.asset_id || '',
+    publicId: payload.public_id || '',
+    url: payload.secure_url || payload.url || '',
+    secureUrl: payload.secure_url || '',
+    resourceType: payload.resource_type || '',
+    format: payload.format || '',
+    bytes: payload.bytes ?? 0,
+    width: payload.width ?? null,
+    height: payload.height ?? null,
+    folder: payload.folder || targetFolder,
+    originalFilename: payload.original_filename || file.name || '',
+    version: payload.version ?? null
+  };
+};
+
+export async function POST(request) {
+  try {
+    const formData = await request.formData();
+    const files = formData.getAll('files');
+    const folder = formData.get('folder');
+
+    const validFiles = files.filter((candidate) => candidate && typeof candidate === 'object' && typeof candidate.arrayBuffer === 'function');
+
+    if (!validFiles.length) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Aucun fichier valide n\'a été fourni.'
+        },
+        { status: 400 }
+      );
+    }
+
+    const uploads = [];
+
+    for (const file of validFiles) {
+      // Upload sequentially to preserve ordering
+      const uploadResult = await uploadToCloudinary(file, { folder });
+      uploads.push(uploadResult);
+    }
+
+    return NextResponse.json({
+      success: true,
+      files: uploads
+    });
+  } catch (error) {
+    console.error('Cloudinary upload error:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: error.message || 'Une erreur est survenue lors du téléversement sur Cloudinary.'
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/cloudinary.js
+++ b/lib/cloudinary.js
@@ -1,0 +1,56 @@
+import crypto from 'crypto';
+
+const cloudName = process.env.CLOUDINARY_CLOUD_NAME ?? '';
+const apiKey = process.env.CLOUDINARY_API_KEY ?? '';
+const apiSecret = process.env.CLOUDINARY_API_SECRET ?? '';
+const baseFolder = process.env.CLOUDINARY_BASE_FOLDER ?? 'portage-salarial';
+
+const isConfigured = Boolean(cloudName && apiKey && apiSecret);
+
+if (!isConfigured) {
+  console.warn(
+    'Cloudinary environment variables are missing. File uploads will fail until CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY and CLOUDINARY_API_SECRET are provided.'
+  );
+}
+
+const cloudinaryConfig = Object.freeze({
+  cloudName,
+  apiKey,
+  apiSecret,
+  baseFolder,
+  isConfigured
+});
+
+const normalizeValue = (value) => {
+  if (Array.isArray(value)) {
+    return value.join(',');
+  }
+
+  return value;
+};
+
+export const createSignature = (params = {}) => {
+  if (!cloudinaryConfig.isConfigured) {
+    throw new Error('Cloudinary configuration is incomplete.');
+  }
+
+  const filteredEntries = Object.entries(params).filter(([, value]) => {
+    return value !== undefined && value !== null && value !== '';
+  });
+
+  const sortedEntries = filteredEntries.sort(([keyA], [keyB]) => {
+    if (keyA < keyB) return -1;
+    if (keyA > keyB) return 1;
+    return 0;
+  });
+
+  const signaturePayload = sortedEntries
+    .map(([key, value]) => `${key}=${normalizeValue(value)}`)
+    .join('&');
+
+  return crypto.createHash('sha1').update(`${signaturePayload}${cloudinaryConfig.apiSecret}`).digest('hex');
+};
+
+export const getCloudinaryConfig = () => cloudinaryConfig;
+
+export default cloudinaryConfig;

--- a/models/SignupApplication.js
+++ b/models/SignupApplication.js
@@ -5,7 +5,19 @@ const FileMetadataSchema = new mongoose.Schema(
     name: { type: String, default: '' },
     size: { type: Number, default: 0 },
     type: { type: String, default: '' },
-    lastModified: { type: Number, default: null }
+    lastModified: { type: Number, default: null },
+    url: { type: String, default: '' },
+    secureUrl: { type: String, default: '' },
+    publicId: { type: String, default: '' },
+    assetId: { type: String, default: '' },
+    resourceType: { type: String, default: '' },
+    format: { type: String, default: '' },
+    bytes: { type: Number, default: 0 },
+    width: { type: Number, default: null },
+    height: { type: Number, default: null },
+    folder: { type: String, default: '' },
+    originalFilename: { type: String, default: '' },
+    version: { type: Number, default: null }
   },
   { _id: false }
 );


### PR DESCRIPTION
## Summary
- add a Cloudinary helper and upload API endpoint that proxies signed uploads to Cloudinary
- update the signup workflow to push owner documents and photos to Cloudinary and store returned metadata
- extend file metadata storage and document the new Cloudinary environment variables

## Testing
- `npm run lint` *(fails: existing react/no-unescaped-entities warnings in multiple files)*

------
https://chatgpt.com/codex/tasks/task_e_68de773e93d0832e871ba90f04da4493