### PR TITLE
Add dedicated CGV pages for owners and renters

### DIFF
--- a/app/cgv-locataires/page.js
+++ b/app/cgv-locataires/page.js
@@ -1,0 +1,174 @@
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+
+export const metadata = {
+  title: 'Conditions Générales de Vente - Locataires',
+  description:
+    'Conditions générales de vente destinées aux locataires utilisant les services de Chalet Manager pour réserver un séjour en montagne.',
+};
+
+const sections = [
+  {
+    title: '1. Champ d’application',
+    paragraphs: [
+      "Les présentes Conditions Générales de Vente (CGV) régissent les réservations de séjours effectuées via Chalet Manager, que ce soit sur notre site internet, par téléphone ou par l’intermédiaire de nos partenaires.",
+      "Toute réservation implique l’acceptation pleine et entière des présentes CGV par le locataire.",
+    ],
+  },
+  {
+    title: '2. Processus de réservation',
+    paragraphs: [
+      "Le locataire sélectionne le bien et les dates souhaités puis complète le formulaire de réservation.",
+      "La réservation est confirmée après versement d’un acompte de 30 % du montant total et réception du contrat signé. À défaut de paiement dans les 72 heures, l’option est automatiquement annulée.",
+      "Le solde est exigible 30 jours avant l’arrivée. Pour les réservations de dernière minute (moins de 30 jours), le paiement intégral est requis à la confirmation.",
+    ],
+  },
+  {
+    title: '3. Prix et taxes',
+    paragraphs: [
+      "Les tarifs affichés incluent la mise à disposition du bien, le linge de maison de base, l’accueil personnalisé et l’assistance Chalet Manager.",
+      "Ne sont pas inclus : la taxe de séjour (facturée selon le tarif en vigueur), les prestations optionnelles (ménage quotidien, chef privé, transferts, etc.) et le dépôt de garantie.",
+      "La taxe de séjour est collectée par Chalet Manager au nom de la collectivité et figure distinctement sur la facture.",
+    ],
+  },
+  {
+    title: '4. Dépôt de garantie',
+    paragraphs: [
+      "Un dépôt de garantie compris entre 1 500 € et 5 000 € selon le bien est exigé avant l’entrée dans les lieux. Il peut être prélevé par empreinte bancaire ou virement.",
+      "Il est restitué dans un délai maximal de 14 jours après le départ, déduction faite des retenues justifiées par des dégradations, pertes ou prestations supplémentaires.",
+    ],
+  },
+  {
+    title: '5. Conditions d’annulation',
+    paragraphs: [
+      "Toute demande d’annulation doit être formulée par écrit. Les frais appliqués sont les suivants :",
+    ],
+    list: [
+      'Annulation plus de 60 jours avant l’arrivée : remboursement de l’acompte moins 150 € de frais de dossier;',
+      'Entre 60 et 30 jours avant l’arrivée : acompte conservé;',
+      'Moins de 30 jours avant l’arrivée ou non-présentation : 100 % du séjour dû;',
+    ],
+    paragraphsAfterList: [
+      "Certaines offres spéciales peuvent prévoir des conditions d’annulation plus strictes signalées au moment de la réservation.",
+      "En cas de fermeture administrative ou de force majeure rendant le séjour impossible, Chalet Manager proposera un report ou un avoir équivalent aux sommes versées.",
+    ],
+  },
+  {
+    title: '6. Arrivée, séjour et départ',
+    paragraphs: [
+      "Les arrivées sont généralement prévues entre 16h00 et 20h00 et les départs avant 10h00, sauf accord écrit contraire.",
+      "Le locataire s’engage à respecter les lieux, le voisinage et le règlement intérieur remis à l’arrivée.",
+      "Toute fête ou sous-location non autorisée est strictement interdite. Chalet Manager se réserve le droit d’interrompre le séjour sans remboursement en cas de manquement grave.",
+    ],
+  },
+  {
+    title: '7. Obligations du locataire',
+    paragraphs: [
+      "Pendant toute la durée du séjour, le locataire doit :",
+    ],
+    list: [
+      'Occuper les lieux en bon père de famille et signaler toute anomalie constatée;',
+      'Limiter l’occupation au nombre de personnes prévu au contrat;',
+      'Ne pas fumer à l’intérieur des biens lorsque cela est stipulé;',
+      'Informer Chalet Manager de tout dommage occasionné et faciliter l’accès des prestataires pour les réparations;',
+      'Respecter les consignes d’utilisation des équipements (spa, cheminée, appareils électriques).',
+    ],
+  },
+  {
+    title: '8. Responsabilités et assurances',
+    paragraphs: [
+      "Chalet Manager agit en tant qu’intermédiaire entre le propriétaire et le locataire. Sa responsabilité ne peut être engagée en cas de force majeure, de fait d’un tiers ou d’utilisation anormale des installations.",
+      "Le locataire est tenu de disposer d’une assurance responsabilité civile villégiature couvrant les dommages corporels, matériels et immatériels causés pendant le séjour.",
+    ],
+  },
+  {
+    title: '9. Données personnelles',
+    paragraphs: [
+      "Les informations collectées lors de la réservation sont nécessaires au traitement de la demande et à la gestion du séjour.",
+      "Elles sont destinées à Chalet Manager et à ses partenaires techniques (prestataires de conciergerie, assureurs). Conformément au RGPD, chaque locataire dispose d’un droit d’accès, de rectification et d’opposition en écrivant à privacy@chaletmanager.com.",
+    ],
+  },
+  {
+    title: '10. Réclamations et médiation',
+    paragraphs: [
+      "Toute réclamation doit être adressée par écrit à Chalet Manager dans un délai de 7 jours après la fin du séjour.",
+      "À défaut de résolution amiable, le locataire peut saisir gratuitement le médiateur de la consommation MEDICYS (www.medicys.fr) ou toute plateforme européenne de règlement en ligne des litiges.",
+    ],
+  },
+  {
+    title: '11. Droit applicable',
+    paragraphs: [
+      "Les présentes CGV sont soumises au droit français. Tout litige relève des tribunaux compétents du lieu de situation du bien loué.",
+    ],
+  },
+];
+
+export default function CgvLocatairesPage() {
+  const lastUpdated = '1er mars 2024';
+
+  return (
+    <>
+      <Header />
+      <main className="bg-neutral-50 pt-24">
+        <section className="bg-primary-900 text-white py-16">
+          <div className="max-w-5xl mx-auto px-6">
+            <p className="uppercase tracking-widest text-primary-200 text-xs mb-4">Conditions Générales de Vente</p>
+            <h1 className="text-3xl md:text-4xl font-semibold mb-6">
+              CGV locataires
+            </h1>
+            <p className="text-base md:text-lg text-primary-100 max-w-3xl">
+              Ce document précise les règles applicables à toute réservation de séjour réalisée auprès de Chalet Manager.
+            </p>
+            <p className="mt-6 text-sm text-primary-200">Dernière mise à jour : {lastUpdated}</p>
+          </div>
+        </section>
+
+        <section className="py-16">
+          <div className="max-w-5xl mx-auto px-6 space-y-12">
+            {sections.map((section) => (
+              <article key={section.title}>
+                <h2 className="text-xl md:text-2xl font-semibold text-neutral-900 mb-4">{section.title}</h2>
+                {section.paragraphs.map((paragraph) => (
+                  <p key={paragraph} className="text-neutral-700 leading-relaxed mb-4">
+                    {paragraph}
+                  </p>
+                ))}
+                {section.list && (
+                  <ul className="list-disc list-inside text-neutral-700 space-y-2">
+                    {section.list.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+                {section.paragraphsAfterList &&
+                  section.paragraphsAfterList.map((paragraph) => (
+                    <p key={paragraph} className="text-neutral-700 leading-relaxed mt-4">
+                      {paragraph}
+                    </p>
+                  ))}
+              </article>
+            ))}
+
+            <div className="border border-primary-100 bg-primary-50 text-primary-900 rounded-xl p-6">
+              <h3 className="text-lg font-semibold mb-2">Service client Chalet Manager</h3>
+              <p className="text-sm text-primary-900/80 mb-4">
+                Pour toute question concernant votre réservation, votre arrivée ou un séjour en cours, notre équipe est joignable 7j/7.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-3 text-sm">
+                <span className="font-medium">Assistance :</span>
+                <a href="mailto:guests@chaletmanager.com" className="text-primary-700 hover:text-primary-800">
+                  guests@chaletmanager.com
+                </a>
+                <span className="hidden sm:block">•</span>
+                <a href="tel:+33456781234" className="text-primary-700 hover:text-primary-800">
+                  +33 4 56 78 12 34
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/app/cgv-proprietaires/page.js
+++ b/app/cgv-proprietaires/page.js
@@ -1,0 +1,170 @@
+import Header from '../../components/layout/Header';
+import Footer from '../../components/layout/Footer';
+
+export const metadata = {
+  title: 'Conditions Générales de Vente - Propriétaires',
+  description:
+    'Conditions générales de vente applicables aux propriétaires partenaires de Chalet Manager pour la gestion et la commercialisation de leurs biens.',
+};
+
+const sections = [
+  {
+    title: '1. Objet du contrat',
+    paragraphs: [
+      "Les présentes Conditions Générales de Vente (CGV) définissent les modalités dans lesquelles Chalet Manager assure la gestion, la commercialisation et l'exploitation locative des biens confiés par leurs propriétaires.",
+      "En signant le mandat de gestion ou en utilisant les services proposés par Chalet Manager, le propriétaire reconnaît avoir pris connaissance des présentes CGV et les accepte sans réserve.",
+    ],
+  },
+  {
+    title: '2. Définitions',
+    paragraphs: [
+      "• \"Chalet Manager\" : la société éditrice du présent site et prestataire de services de gestion locative.",
+      "• \"Propriétaire\" : toute personne physique ou morale confiant un bien immobilier à Chalet Manager.",
+      "• \"Bien\" : chalet, appartement ou toute propriété située en zone de montagne confiée à Chalet Manager.",
+      "• \"Locataire\" : client final concluant un contrat de location pour le bien géré.",
+    ],
+  },
+  {
+    title: '3. Prestations de Chalet Manager',
+    paragraphs: [
+      "Chalet Manager fournit, selon le niveau d'accompagnement défini avec le propriétaire, les services suivants :",
+    ],
+    list: [
+      'Analyse de rentabilité et définition de la stratégie commerciale du bien;',
+      'Création, diffusion et optimisation des annonces sur les canaux partenaires et le site Chalet Manager;',
+      'Gestion des demandes, réservations, encaissements et contrats de location;',
+      'Accueil des locataires, conciergerie, intendance et suivi de la satisfaction;',
+      'Organisation de la maintenance préventive et curative, gestion des prestataires techniques;',
+      'Reporting financier, reversements et assistance administrative (taxes de séjour, fiscalité).',
+    ],
+  },
+  {
+    title: '4. Obligations du propriétaire',
+    paragraphs: [
+      "Le propriétaire s'engage à :",
+    ],
+    list: [
+      'Fournir un bien conforme aux normes de sécurité, d’hygiène et de décence en vigueur;',
+      'Déclarer la propriété auprès des autorités compétentes et disposer des autorisations nécessaires;',
+      'Informer Chalet Manager de toute particularité juridique ou technique susceptible d’affecter l’exploitation du bien;',
+      'Souscrire et maintenir une assurance multirisque habitation couvrant la location saisonnière;',
+      'Régler les charges de copropriété, taxes foncières et autres frais non imputables à Chalet Manager;',
+      'Faciliter l’accès au bien pour les opérations d’entretien et de contrôle convenues.'
+    ],
+  },
+  {
+    title: '5. Obligations de Chalet Manager',
+    paragraphs: [
+      "Chalet Manager s’engage à :",
+    ],
+    list: [
+      'Mettre en œuvre les moyens nécessaires pour optimiser le taux d’occupation et la rentabilité du bien;',
+      'Assurer une communication transparente via un reporting périodique (planning d’occupation, revenus, interventions);',
+      'Respecter les lois et règlements applicables à la location meublée de tourisme;',
+      'Sélectionner des locataires fiables et veiller au bon déroulement des séjours;',
+      'Réagir dans les meilleurs délais en cas d’incident nécessitant une intervention;',
+      'Conserver la confidentialité des informations communiquées par le propriétaire.'
+    ],
+  },
+  {
+    title: '6. Conditions financières',
+    paragraphs: [
+      "Les honoraires de Chalet Manager sont calculés sur la base du chiffre d’affaires locatif généré. Le pourcentage appliqué, les forfaits de conciergerie et les frais d’entretien sont précisés dans le mandat ou l’offre commerciale signée.",
+      "Le reversement des loyers nets intervient mensuellement, déduction faite des commissions, frais engagés et taxes collectées. Un relevé détaillé est transmis à chaque échéance.",
+      "Toute prestation additionnelle validée par le propriétaire fera l’objet d’un devis et d’une facturation complémentaire.",
+    ],
+  },
+  {
+    title: '7. Durée et résiliation',
+    paragraphs: [
+      "Le mandat de gestion est conclu pour une durée initiale d’un an renouvelable tacitement, sauf dispositions contraires.",
+      "Chaque partie peut y mettre fin à l’expiration de la période en cours, moyennant un préavis écrit de 60 jours. La résiliation anticipée est possible en cas de manquement grave avéré, après mise en demeure restée sans effet pendant 30 jours.",
+      "Les réservations confirmées avant la date effective de résiliation doivent être honorées. Chalet Manager percevra la rémunération due au titre de ces séjours.",
+    ],
+  },
+  {
+    title: '8. Responsabilité et assurances',
+    paragraphs: [
+      "Chalet Manager agit en qualité de mandataire. Sa responsabilité ne saurait être engagée en cas de force majeure ou de dommages imputables aux locataires, sous-traitants ou à un défaut structurel du bien.",
+      "Le propriétaire demeure responsable des sinistres non couverts par l’assurance de Chalet Manager ou par celle des locataires. Il appartient au propriétaire de déclarer tout sinistre à son assureur et de coopérer avec Chalet Manager pour la constitution du dossier.",
+    ],
+  },
+  {
+    title: '9. Données personnelles',
+    paragraphs: [
+      "Chalet Manager collecte et traite les données personnelles nécessaires à l’exécution du mandat (coordonnées, informations bancaires, documents administratifs).",
+      "Ces données sont conservées pendant toute la durée de la collaboration et archivées pendant la période légale. Conformément à la réglementation RGPD, le propriétaire dispose d’un droit d’accès, de rectification, d’opposition et de suppression en écrivant à privacy@chaletmanager.com.",
+    ],
+  },
+  {
+    title: '10. Droit applicable et litiges',
+    paragraphs: [
+      "Les présentes CGV sont soumises au droit français. Tout différend relatif à leur interprétation ou exécution qui ne pourrait être résolu à l’amiable sera soumis aux tribunaux compétents du ressort de la Cour d’appel d’Annecy.",
+      "Pour toute question relative aux présentes CGV, le propriétaire peut contacter Chalet Manager à l’adresse suivante : legal@chaletmanager.com.",
+    ],
+  },
+];
+
+export default function CgvProprietairesPage() {
+  const lastUpdated = '1er mars 2024';
+
+  return (
+    <>
+      <Header />
+      <main className="bg-neutral-50 pt-24">
+        <section className="bg-primary-900 text-white py-16">
+          <div className="max-w-5xl mx-auto px-6">
+            <p className="uppercase tracking-widest text-primary-200 text-xs mb-4">Conditions Générales de Vente</p>
+            <h1 className="text-3xl md:text-4xl font-semibold mb-6">
+              CGV propriétaires partenaires
+            </h1>
+            <p className="text-base md:text-lg text-primary-100 max-w-3xl">
+              Ce document encadre la collaboration entre Chalet Manager et les propriétaires qui nous confient la gestion locative de leur bien.
+            </p>
+            <p className="mt-6 text-sm text-primary-200">Dernière mise à jour : {lastUpdated}</p>
+          </div>
+        </section>
+
+        <section className="py-16">
+          <div className="max-w-5xl mx-auto px-6 space-y-12">
+            {sections.map((section) => (
+              <article key={section.title}>
+                <h2 className="text-xl md:text-2xl font-semibold text-neutral-900 mb-4">{section.title}</h2>
+                {section.paragraphs.map((paragraph) => (
+                  <p key={paragraph} className="text-neutral-700 leading-relaxed mb-4">
+                    {paragraph}
+                  </p>
+                ))}
+                {section.list && (
+                  <ul className="list-disc list-inside text-neutral-700 space-y-2">
+                    {section.list.map((item) => (
+                      <li key={item}>{item}</li>
+                    ))}
+                  </ul>
+                )}
+              </article>
+            ))}
+
+            <div className="border border-primary-100 bg-primary-50 text-primary-900 rounded-xl p-6">
+              <h3 className="text-lg font-semibold mb-2">Besoin d’un complément d’information ?</h3>
+              <p className="text-sm text-primary-900/80 mb-4">
+                Notre équipe reste à votre disposition pour adapter un mandat sur-mesure et répondre à toutes vos questions juridiques, financières ou opérationnelles.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-3 text-sm">
+                <span className="font-medium">Contact :</span>
+                <a href="mailto:owners@chaletmanager.com" className="text-primary-700 hover:text-primary-800">
+                  owners@chaletmanager.com
+                </a>
+                <span className="hidden sm:block">•</span>
+                <a href="tel:+33123456789" className="text-primary-700 hover:text-primary-800">
+                  +33 1 23 45 67 89
+                </a>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/components/layout/Footer.js
+++ b/components/layout/Footer.js
@@ -25,6 +25,8 @@ export default function Footer() {
       { name: 'Terms of Service', href: '/terms' },
       { name: 'Cookie Policy', href: '/cookies' },
       { name: 'Legal Notice', href: '/legal' },
+      { name: 'CGV Propriétaires', href: '/cgv-proprietaires' },
+      { name: 'CGV Locataires', href: '/cgv-locataires' },
     ],
     social: [
       { name: 'Facebook', href: '#', icon: Facebook },


### PR DESCRIPTION
## Summary
- create dedicated CGV pages for property owners and renters with SEO metadata and structured legal content
- surface the new CGV routes within the footer's legal navigation links for easy access

## Testing
- npm run lint *(fails: existing `react/no-unescaped-entities` violations in legacy files)*

------
https://chatgpt.com/codex/tasks/task_e_68de794e6c50832e86181d10b74e6837