### PR TITLE
Add CGV consent modals to signup flow

### DIFF
--- a/models/SignupApplication.js
+++ b/models/SignupApplication.js
@@ -63,6 +63,7 @@ const OwnerApplicationSchema = new mongoose.Schema(
     longDescription: { type: String, default: '' },
     heroPhoto: { type: [FileMetadataSchema], default: [] },
     gallery: { type: [FileMetadataSchema], default: [] },
+    portfolioGallery: { type: [FileMetadataSchema], default: [] },
     rooms: { type: [RoomSchema], default: [] },
     propertyAddress: { type: AddressSchema, default: () => ({}) },
     mainAddress: { type: AddressSchema, default: () => ({}) },


### PR DESCRIPTION
## Summary
- require CGV acceptance for owner and tenant signups via a dedicated modal and success confirmation overlay
- persist uploaded owner media in a portfolio gallery field when building signup payloads

## Testing
- npm run lint *(fails: pre-existing react/no-unescaped-entities warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e003a57a68832eb814c40793712e4d