### PR TITLE
Reset sign-up flow after modal dismissal

### DIFF
--- a/app/signup/page.js
+++ b/app/signup/page.js
@@ -276,6 +276,15 @@ export default function SignUpPage() {
 
   const handleSuccessModalClose = () => {
     setSuccessModal({ open: false, type: null, message: "" });
+    resetFeedback();
+    setSelectedOption(null);
+    setOwnerForm(createOwnerInitial());
+    setTenantForm(createTenantInitial());
+    setOwnerActiveModule("owner-chalet");
+    setTenantActiveModule("tenant-profile");
+    setOwnerExpandedRooms([true]);
+    setOwnerAcceptedCGV(false);
+    setTenantAcceptedCGV(false);
   };
 
   const ownerModuleStatus = useMemo(() => {


### PR DESCRIPTION
## Summary
- reset the signup success modal handler to restore the initial landing view once dismissed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0283e5b08832e8d07bd1a012dbd2f