### PR TITLE
Add Cloudinary configuration status checks to signup flow

### DIFF
--- a/app/api/uploads/config/route.js
+++ b/app/api/uploads/config/route.js
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { getCloudinaryConfig } from "../../../../lib/cloudinary";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const config = getCloudinaryConfig();
+  const configured = Boolean(config?.isConfigured);
+
+  const response = {
+    success: true,
+    configured,
+    message: configured
+      ? "Cloudinary est configuré."
+      : "Cloudinary n'est pas configuré. Merci de définir CLOUDINARY_CLOUD_NAME, CLOUDINARY_API_KEY et CLOUDINARY_API_SECRET.",
+  };
+
+  if (configured) {
+    response.details = {
+      baseFolder: config?.baseFolder || "",
+    };
+  }
+
+  return NextResponse.json(response);
+}


### PR DESCRIPTION
## Summary
- add a Cloudinary configuration status API endpoint used by the signup experience
- surface the Cloudinary status banner in the signup flow and block submissions when uploads are misconfigured
- provide clearer messaging when Cloudinary environment variables are missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e260386430832e808a25b3bc586cf8