### PR TITLE
Fix owner role validation in user schema

### DIFF
--- a/models/User.js
+++ b/models/User.js
@@ -1,7 +1,7 @@
 import mongoose from 'mongoose';
 import bcrypt from 'bcryptjs';
 
-const ROLE_VALUES = ['admin', 'super-admin', 'manager', 'owner'];
+const ROLE_VALUES = Object.freeze(['admin', 'super-admin', 'manager', 'owner']);
 const ADMIN_ROLES = new Set(['admin', 'super-admin', 'owner']);
 
 const normalizeRole = (role) => {
@@ -111,5 +111,15 @@ UserSchema.methods.hasAdminAccess = function() {
 UserSchema.virtual('isAdminRole').get(function() {
   return ADMIN_ROLES.has(this.role);
 });
+const existingModel = mongoose.models.User;
 
-export default mongoose.models.User || mongoose.model('User', UserSchema);
+if (existingModel) {
+  const rolePath = existingModel.schema?.path('role');
+
+  if (rolePath?.options?.enum && !rolePath.options.enum.includes('owner')) {
+    rolePath.enumValues.push('owner');
+    rolePath.options.enum.push('owner');
+  }
+}
+
+export default existingModel || mongoose.model('User', UserSchema);


### PR DESCRIPTION
## Summary
- ensure the user role enum always includes the owner role when the model is reused
- freeze the role value list so it cannot be mutated elsewhere

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e26c8a942c832eb3b02d040527e878