### PR TITLE
Delay MongoDB env validation until connection

### DIFF
--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1,10 +1,6 @@
 import mongoose from 'mongoose';
 
-const MONGODB_URI = process.env.MONGODB_URI;
-
-if (!MONGODB_URI) {
-  throw new Error('Please define the MONGODB_URI environment variable inside .env');
-}
+const { MONGODB_URI } = process.env;
 
 /**
  * Global is used here to maintain a cached connection across hot reloads
@@ -18,6 +14,10 @@ if (!cached) {
 }
 
 async function dbConnect() {
+  if (!MONGODB_URI) {
+    throw new Error('Please define the MONGODB_URI environment variable inside .env');
+  }
+
   if (cached.conn) {
     return cached.conn;
   }


### PR DESCRIPTION
## Summary
- avoid throwing during module load when MONGODB_URI is missing
- validate the environment variable when attempting to connect to MongoDB

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27254103c832eb63f5a15c4927b9b