### PR TITLE
Add super admin property visibility toggle and signup insights

### DIFF
--- a/app/api/chalets/[slug]/route.js
+++ b/app/api/chalets/[slug]/route.js
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import dbConnect from '../../../../lib/mongodb';
 import Chalet from '../../../../models/Chalet';
-import { requireAuth } from '../../../../lib/auth';
+import { requireAuth, verifyToken } from '../../../../lib/auth';
 
 // Get single chalet by slug
 export async function GET(request, { params }) {
@@ -96,6 +96,119 @@ export async function PUT(request, { params }) {
       );
     }
   })(request);
+}
+
+export async function PATCH(request, { params }) {
+  try {
+    const authHeader = request.headers.get('authorization') || '';
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : null;
+
+    if (!token) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Access token is required'
+        },
+        { status: 401 }
+      );
+    }
+
+    let user;
+    try {
+      user = await verifyToken(token);
+    } catch (error) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Invalid or expired token'
+        },
+        { status: 401 }
+      );
+    }
+
+    if (user?.role !== 'super-admin') {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Insufficient permissions'
+        },
+        { status: 403 }
+      );
+    }
+
+    await dbConnect();
+
+    const { slug } = params;
+    const body = await request.json();
+
+    const updates = {};
+
+    if (body?.availability?.isActive !== undefined) {
+      updates['availability.isActive'] = body.availability.isActive;
+    }
+
+    for (const [key, value] of Object.entries(body || {})) {
+      if (key !== 'availability') {
+        updates[key] = value;
+      }
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'No valid fields provided for update'
+        },
+        { status: 400 }
+      );
+    }
+
+    const updatePayload = {};
+    const directKeys = ['title', 'description', 'shortDescription', 'featured', 'pricing', 'location', 'images', 'amenities', 'specifications', 'availability', 'contact', 'seo'];
+
+    for (const [key, value] of Object.entries(updates)) {
+      if (key.includes('.')) {
+        updatePayload.$set = { ...(updatePayload.$set || {}), [key]: value };
+      } else if (directKeys.includes(key)) {
+        updatePayload[key] = value;
+      } else {
+        updatePayload.$set = { ...(updatePayload.$set || {}), [key]: value };
+      }
+    }
+
+    const chalet = await Chalet.findOneAndUpdate(
+      { slug },
+      updatePayload,
+      { new: true, runValidators: true }
+    );
+
+    if (!chalet) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: 'Chalet not found'
+        },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Chalet updated successfully',
+      data: chalet
+    });
+  } catch (error) {
+    console.error('Error partially updating chalet:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: 'Failed to update chalet'
+      },
+      { status: 500 }
+    );
+  }
 }
 
 // Delete chalet (protected)


### PR DESCRIPTION
## Summary
- expose owner signup applications to super administrators via a protected API and dashboard widget
- add a property visibility toggle in the super admin dashboard backed by a PATCH endpoint
- allow authorized super admins to retrieve inactive chalets for management while keeping the public portfolio unchanged

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e283a2c80c832e88b77d7280f94f33