### PR TITLE
Allow removing default PageWrapper padding

### DIFF
--- a/app/seminaires-evenements/page.js
+++ b/app/seminaires-evenements/page.js
@@ -176,7 +176,10 @@ export default function SeminairesEvenementsPage() {
   ];
 
   return (
-    <PageWrapper mainClassName="space-y-24 bg-neutral-50 pt-0 md:pt-6 pb-24 md:pb-32">
+    <PageWrapper
+      disableMainPadding
+      mainClassName="space-y-24 bg-neutral-50 pt-0 pb-24 md:pb-32"
+    >
       {/* Hero Section */}
       <section className="relative flex min-h-[70vh] items-center justify-center overflow-hidden rounded-none text-white">
         <div className="absolute inset-0 z-0">

--- a/components/layout/PageWrapper.js
+++ b/components/layout/PageWrapper.js
@@ -2,11 +2,20 @@ import Header from './Header';
 import Footer from './Footer';
 import { cn } from '../../lib/utils.ts';
 
-export default function PageWrapper({ children, className, mainClassName }) {
+export default function PageWrapper({
+  children,
+  className,
+  mainClassName,
+  disableMainPadding = false,
+}) {
   return (
     <div className={cn('flex min-h-screen flex-col bg-neutral-50 text-neutral-900', className)}>
       <Header />
-      <main className={cn('flex-1 py-16 md:py-20', mainClassName)}>{children}</main>
+      <main
+        className={cn('flex-1', disableMainPadding ? null : 'py-16 md:py-20', mainClassName)}
+      >
+        {children}
+      </main>
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- add an option on PageWrapper to disable its default main padding wrapper
- disable the main padding on the Séminaires & Événements page so the hero touches the header

## Testing
- npm run lint *(fails: existing lint errors in app/chalet/[slug]/page.js and components/forms/FileDropzone.js)*

------
https://chatgpt.com/codex/tasks/task_e_68fa6797eeb8832e9156447a45d2b995